### PR TITLE
Docs : Fix wrong exemple of typescript config

### DIFF
--- a/docs/docs/visual-testing-with-storybook.md
+++ b/docs/docs/visual-testing-with-storybook.md
@@ -102,8 +102,8 @@ module.exports = ({ config }) => {
 > When using TypeScript, add this rule:
 
 ```js:title=.storybook/webpack.config.js
-
-config.module.rules.push({
+module.exports = ({ config }) => {
+  config.module.rules.push({
     test: /\.(ts|tsx)$/,
     loader: require.resolve('babel-loader'),
     options: {


### PR DESCRIPTION
## Description

Fixed the webpack.config.js example of the typescript storybook version.